### PR TITLE
Update daily build workflow to use dist bundle for data generation

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Generate menu data
-        run: npm run generate:data
-
       - name: Build browser bundle
         run: npm run build:menu
+
+      - name: Generate menu data from dist build
+        run: node dist/menu.js --generate --out data/menu-data.json
 
       - name: Upload menu assets
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update the daily build workflow to build the browser bundle before generating menu data
- run the CLI from the built dist/menu.js so the JSON file is written to data/menu-data.json

## Testing
- npm install
- npm run build:menu
- MENU_API=dummy node dist/menu.js --generate --out data/menu-data.json *(fails: network access to open.neis.go.kr is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9efded5e4832a91b96b1ed8565bf8