### PR TITLE
Enable daily workflow to publish menu data updates

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-menu:
     runs-on: ubuntu-latest
@@ -35,3 +38,15 @@ jobs:
           path: |
             data/menu-data.json
             dist/menu.js
+
+      - name: Commit and push updated menu data
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/menu-data.json
+          if git diff --cached --quiet; then
+            echo "No menu data changes to commit."
+          else
+            git commit -m "chore: update menu data"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- grant the daily build workflow permission to update repository contents
- commit and push regenerated `data/menu-data.json` when changes are detected

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68c9f28ed9d4832abc7f4c98a1ebc882