### PR TITLE
Use label trigger for menu date picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,16 @@
                 id="menuDateInput"
                 aria-label="급식 날짜 선택"
               />
-              <button type="button" id="menuDateButton" class="calendar-button">
+              <!-- button 대신 label 사용 -->
+              <label
+                for="menuDateInput"
+                id="menuDateButton"
+                class="calendar-button"
+                role="button"
+              >
                 <span aria-hidden="true">📅</span>
                 <span class="calendar-button__label">날짜 선택</span>
-              </button>
+              </label>
             </div>
             <div class="menu-card__meta">
               <p id="selectedDateLabel" class="menu-card__date">로딩 중...</p>

--- a/menu.js
+++ b/menu.js
@@ -47,20 +47,23 @@
   }
 
   function attachEvents() {
+    // label 클릭으로 열리므로 실제로는 핸들러가 필요 없지만,
+    // showPicker 지원 브라우저(안드로이드 크롬 등)에서 즉시 열기 최적화:
     if (dom.dateButton && dom.dateInput) {
-      dom.dateButton.addEventListener("click", function () {
+      dom.dateButton.addEventListener("click", (e) => {
         if (typeof dom.dateInput.showPicker === "function") {
           dom.dateInput.showPicker();
-        } else {
-          dom.dateInput.focus();
+          e.preventDefault(); // 이중 오픈 방지
         }
+        // 미지원(iOS)에서는 label 클릭 자체로 피커가 열립니다.
       });
     }
 
     if (dom.dateInput) {
-      dom.dateInput.addEventListener("input", function (event) {
-        updateSelectedDate(event.target.value);
-      });
+      // iOS 대응: change도 함께 리슨
+      const onPick = (e) => updateSelectedDate(e.target.value);
+      dom.dateInput.addEventListener("input", onPick);
+      dom.dateInput.addEventListener("change", onPick);
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the date picker button with an accessible label control in the menu card
- adjust event handling to optimize showPicker usage and listen to change events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca2e5a9ae8832aa1aea2aede12c267