### PR TITLE
Revise date picker styling and interactions

### DIFF
--- a/dist/menu.js
+++ b/dist/menu.js
@@ -40,7 +40,9 @@
 
   function cacheDom() {
     dom.dateInput = document.getElementById("menuDateInput");
-    dom.dateButton = document.getElementById("menuDateButton");
+    dom.dateButton = document.querySelector(
+      ".menu-card__date-picker .calendar-button"
+    );
     dom.dateLabel = document.getElementById("selectedDateLabel");
     dom.updatedLabel = document.getElementById("menuUpdatedAt");
     dom.tableBody = document.getElementById("menuTableBody");
@@ -48,19 +50,22 @@
   }
 
   function attachEvents() {
-    if (dom.dateButton && dom.dateInput) {
-      dom.dateButton.addEventListener("click", function () {
-        if (typeof dom.dateInput.showPicker === "function") {
-          dom.dateInput.showPicker();
-        } else {
-          dom.dateInput.focus();
-        }
+    if (dom.dateInput) {
+      dom.dateInput.addEventListener("change", function (event) {
+        updateSelectedDate(event.target.value);
+      });
+
+      dom.dateInput.addEventListener("input", function (event) {
+        updateSelectedDate(event.target.value);
       });
     }
 
-    if (dom.dateInput) {
-      dom.dateInput.addEventListener("input", function (event) {
-        updateSelectedDate(event.target.value);
+    if (dom.dateButton) {
+      dom.dateButton.addEventListener("click", function () {
+        if (dom.dateInput) {
+          dom.dateInput.focus();
+          dom.dateInput.click();
+        }
       });
     }
   }

--- a/index.html
+++ b/index.html
@@ -23,16 +23,10 @@
                 id="menuDateInput"
                 aria-label="급식 날짜 선택"
               />
-              <!-- button 대신 label 사용 -->
-              <label
-                for="menuDateInput"
-                id="menuDateButton"
-                class="calendar-button"
-                role="button"
-              >
+              <div class="calendar-button">
                 <span aria-hidden="true">📅</span>
                 <span class="calendar-button__label">날짜 선택</span>
-              </label>
+              </div>
             </div>
             <div class="menu-card__meta">
               <p id="selectedDateLabel" class="menu-card__date">로딩 중...</p>

--- a/menu.js
+++ b/menu.js
@@ -39,7 +39,9 @@
 
   function cacheDom() {
     dom.dateInput = document.getElementById("menuDateInput");
-    dom.dateButton = document.getElementById("menuDateButton");
+    dom.dateButton = document.querySelector(
+      ".menu-card__date-picker .calendar-button"
+    );
     dom.dateLabel = document.getElementById("selectedDateLabel");
     dom.updatedLabel = document.getElementById("menuUpdatedAt");
     dom.tableBody = document.getElementById("menuTableBody");
@@ -47,23 +49,25 @@
   }
 
   function attachEvents() {
-    // label 클릭으로 열리므로 실제로는 핸들러가 필요 없지만,
-    // showPicker 지원 브라우저(안드로이드 크롬 등)에서 즉시 열기 최적화:
-    if (dom.dateButton && dom.dateInput) {
-      dom.dateButton.addEventListener("click", (e) => {
-        if (typeof dom.dateInput.showPicker === "function") {
-          dom.dateInput.showPicker();
-          e.preventDefault(); // 이중 오픈 방지
-        }
-        // 미지원(iOS)에서는 label 클릭 자체로 피커가 열립니다.
+    if (dom.dateInput) {
+      // 더 안정적인 이벤트 처리
+      dom.dateInput.addEventListener("change", (e) => {
+        updateSelectedDate(e.target.value);
+      });
+
+      dom.dateInput.addEventListener("input", (e) => {
+        updateSelectedDate(e.target.value);
       });
     }
 
-    if (dom.dateInput) {
-      // iOS 대응: change도 함께 리슨
-      const onPick = (e) => updateSelectedDate(e.target.value);
-      dom.dateInput.addEventListener("input", onPick);
-      dom.dateInput.addEventListener("change", onPick);
+    // showPicker() 관련 코드 제거하고 단순화
+    if (dom.dateButton) {
+      dom.dateButton.addEventListener("click", () => {
+        if (dom.dateInput) {
+          dom.dateInput.focus();
+          dom.dateInput.click();
+        }
+      });
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -68,17 +68,18 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
 }
 
 #menuDateInput {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  border: 0;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 2;
 }
 
 .calendar-button {
@@ -94,6 +95,8 @@ body {
   cursor: pointer;
   box-shadow: 0 8px 16px -12px rgba(25, 118, 210, 0.9);
   transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+  position: relative;
+  z-index: 1;
 }
 
 .calendar-button:focus-visible,


### PR DESCRIPTION
## Summary
- restyle the menu date picker so the hidden input overlays the visible calendar button while keeping the trigger accessible
- replace the label-based calendar trigger with a div button in the markup
- simplify the JavaScript date picker listeners to react to both change and input events and focus the input when the button is clicked

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca31ed3258832ab822c0f256f599c7