### PR TITLE
Wrap date picker input with label

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,17 +22,17 @@
       <main class="page__content" id="mealInfoWrapper">
         <section class="menu-card" aria-live="polite">
           <div class="menu-card__controls">
-            <div class="menu-card__date-picker">
+            <label class="menu-card__date-picker">
               <input
                 type="date"
                 id="menuDateInput"
                 aria-label="급식 날짜 선택"
               />
-              <div class="calendar-button">
+              <span class="calendar-button">
                 <span aria-hidden="true">📅</span>
                 <span class="calendar-button__label">날짜 선택</span>
-              </div>
-            </div>
+              </span>
+            </label>
             <div class="menu-card__meta">
               <p id="selectedDateLabel" class="menu-card__date">로딩 중...</p>
               <p id="menuUpdatedAt" class="menu-card__updated"></p>

--- a/style.css
+++ b/style.css
@@ -70,6 +70,8 @@ body {
   gap: 0.5rem;
   position: relative;
   min-height: 44px; /* Ensure minimum touch target */
+  cursor: pointer;
+  touch-action: manipulation;
 }
 
 #menuDateInput {
@@ -84,6 +86,7 @@ body {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  font-size: 16px; /* Prevent iOS Safari zoom */
 }
 
 .calendar-button {


### PR DESCRIPTION
## Summary
- wrap the date picker markup in an accessible `<label>` so the custom button is consistently tappable
- adjust the date picker styles to add pointer/touch affordances and prevent iOS zoom when focusing the input

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca97490954832a94feec4a28b1af2f