### PR TITLE
Adjust calendar button behavior by device capabilities

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,7 +104,6 @@ body {
   transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
   position: relative;
   z-index: 1;
-  pointer-events: none; /* Allow the invisible input above to capture the tap */
 }
 
 .menu-card__date-picker:focus-within .calendar-button,
@@ -185,6 +184,29 @@ body {
   margin-top: calc(var(--spacing-unit) * 1.1);
   font-size: 0.95rem;
   color: var(--text-secondary);
+}
+
+/* For touch devices (iOS, Android, etc.) */
+@media (hover: none) and (pointer: coarse) {
+  #menuDateInput {
+    opacity: 0;
+    pointer-events: auto; /* let input capture taps */
+  }
+
+  .calendar-button {
+    pointer-events: none; /* button is only decoration */
+  }
+}
+
+/* For desktop (mouse/trackpad) */
+@media (hover: hover) and (pointer: fine) {
+  #menuDateInput {
+    display: none; /* hide the input entirely */
+  }
+
+  .calendar-button {
+    pointer-events: auto; /* button works normally */
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- add media queries to toggle the date input and calendar button behavior based on pointer and hover support
- ensure the calendar button remains interactive on desktop while touch devices route taps to the native input

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca99829fa8832a86f8fbd63d78fd73