### PR TITLE
Render nutrition information (NTR_INFO) with calories in menu table

### DIFF
--- a/dist/menu.js
+++ b/dist/menu.js
@@ -1,4 +1,4 @@
-// Built on 2026-05-28T02:23:40.168Z
+// Built on 2026-05-28T02:40:38.700Z
 (function (global) {
   const MENU_JSON_PATH = "data/menu-data.json";
   const MEAL_SERVICE_API_URL = "https://open.neis.go.kr/hub/mealServiceDietInfo";
@@ -236,7 +236,8 @@
       const menuCell = document.createElement("td");
       const mealEntry = menuForDate[mealType] || {};
       const dishes = Array.isArray(mealEntry.items) ? mealEntry.items : [];
-      const calories = typeof mealEntry.calories === "string" ? mealEntry.calories : "-";
+      const nutritionInfo = typeof mealEntry.nutritionInfo === "string" ? mealEntry.nutritionInfo : "";
+      const calories = typeof mealEntry.calories === "string" ? mealEntry.calories : "";
 
       const list = document.createElement("ul");
       if (dishes.length === 0) {
@@ -252,12 +253,20 @@
       }
       menuCell.appendChild(list);
 
-      const calorieCell = document.createElement("td");
-      calorieCell.textContent = calories || "-";
+      const nutritionCell = document.createElement("td");
+      const nutritionLines = [];
+      if (calories) {
+        nutritionLines.push(`열량: ${calories}`);
+      }
+      if (nutritionInfo) {
+        nutritionLines.push(`영양: ${nutritionInfo}`);
+      }
+      nutritionCell.textContent = nutritionLines.length ? nutritionLines.join("\n") : "-";
+      nutritionCell.style.whiteSpace = "pre-line";
 
       row.appendChild(mealCell);
       row.appendChild(menuCell);
-      row.appendChild(calorieCell);
+      row.appendChild(nutritionCell);
       dom.tableBody.appendChild(row);
     });
 
@@ -493,15 +502,16 @@
 
         if (!accumulator[dateKey]) {
           accumulator[dateKey] = {
-            breakfast: { items: [], calories: "" },
-            lunch: { items: [], calories: "" },
-            dinner: { items: [], calories: "" },
+            breakfast: { items: [], calories: "", nutritionInfo: "" },
+            lunch: { items: [], calories: "", nutritionInfo: "" },
+            dinner: { items: [], calories: "", nutritionInfo: "" },
           };
         }
 
         accumulator[dateKey][mealType] = {
           items: parseDishList(row?.DDISH_NM),
           calories: typeof row?.CAL_INFO === "string" ? row.CAL_INFO.trim() : "",
+          nutritionInfo: typeof row?.NTR_INFO === "string" ? row.NTR_INFO.trim() : "",
         };
         return accumulator;
       }, {});

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
               <tr>
                 <th scope="col">식사</th>
                 <th scope="col">메뉴</th>
-                <th scope="col">열량</th>
+                <th scope="col">영양 정보</th>
               </tr>
             </thead>
             <tbody id="menuTableBody">

--- a/menu.js
+++ b/menu.js
@@ -235,7 +235,8 @@
       const menuCell = document.createElement("td");
       const mealEntry = menuForDate[mealType] || {};
       const dishes = Array.isArray(mealEntry.items) ? mealEntry.items : [];
-      const calories = typeof mealEntry.calories === "string" ? mealEntry.calories : "-";
+      const nutritionInfo = typeof mealEntry.nutritionInfo === "string" ? mealEntry.nutritionInfo : "";
+      const calories = typeof mealEntry.calories === "string" ? mealEntry.calories : "";
 
       const list = document.createElement("ul");
       if (dishes.length === 0) {
@@ -251,12 +252,20 @@
       }
       menuCell.appendChild(list);
 
-      const calorieCell = document.createElement("td");
-      calorieCell.textContent = calories || "-";
+      const nutritionCell = document.createElement("td");
+      const nutritionLines = [];
+      if (calories) {
+        nutritionLines.push(`열량: ${calories}`);
+      }
+      if (nutritionInfo) {
+        nutritionLines.push(`영양: ${nutritionInfo}`);
+      }
+      nutritionCell.textContent = nutritionLines.length ? nutritionLines.join("\n") : "-";
+      nutritionCell.style.whiteSpace = "pre-line";
 
       row.appendChild(mealCell);
       row.appendChild(menuCell);
-      row.appendChild(calorieCell);
+      row.appendChild(nutritionCell);
       dom.tableBody.appendChild(row);
     });
 
@@ -492,15 +501,16 @@
 
         if (!accumulator[dateKey]) {
           accumulator[dateKey] = {
-            breakfast: { items: [], calories: "" },
-            lunch: { items: [], calories: "" },
-            dinner: { items: [], calories: "" },
+            breakfast: { items: [], calories: "", nutritionInfo: "" },
+            lunch: { items: [], calories: "", nutritionInfo: "" },
+            dinner: { items: [], calories: "", nutritionInfo: "" },
           };
         }
 
         accumulator[dateKey][mealType] = {
           items: parseDishList(row?.DDISH_NM),
           calories: typeof row?.CAL_INFO === "string" ? row.CAL_INFO.trim() : "",
+          nutritionInfo: typeof row?.NTR_INFO === "string" ? row.NTR_INFO.trim() : "",
         };
         return accumulator;
       }, {});


### PR DESCRIPTION
### Motivation

- Display both caloric and nutrition details provided by the meal API together in the menu UI instead of only showing a single calories column.
- Capture the `NTR_INFO` field from the upstream data so nutrition details are preserved and shown to users.

### Description

- Update the table header in `index.html` to `영양 정보` to reflect combined nutrition content instead of only `열량`.
- Add a `nutritionInfo` property to menu entries and initialize it in `transformRowsToMenus`, and populate it from `row?.NTR_INFO` when present.
- Change rendering in `menu.js`/`dist/menu.js` to combine calories and nutrition lines into a single table cell, join lines with a newline, and set `white-space: pre-line` so both pieces display on separate lines.
- Adjust default handling so empty values become `"-"` in the UI while internal defaults are empty strings, and update the built `dist/menu.js` artifact timestamp.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17a9bcd39c8331bf82bd9fd4f481cd)