### PR TITLE
Adjust font size for nutrition info cells

### DIFF
--- a/dist/menu.js
+++ b/dist/menu.js
@@ -1,4 +1,4 @@
-// Built on 2026-05-28T02:50:03.295Z
+// Built on 2026-05-28T03:00:06.657Z
 (function (global) {
   const MENU_JSON_PATH = "data/menu-data.json";
   const MEAL_SERVICE_API_URL = "https://open.neis.go.kr/hub/mealServiceDietInfo";
@@ -263,6 +263,7 @@
       menuCell.appendChild(list);
 
       const nutritionCell = document.createElement("td");
+      nutritionCell.className = "menu-table__nutrition";
       const nutritionLines = [];
       if (calories) {
         nutritionLines.push(`열량: ${escapeHtml(calories)}`);

--- a/menu.js
+++ b/menu.js
@@ -262,6 +262,7 @@
       menuCell.appendChild(list);
 
       const nutritionCell = document.createElement("td");
+      nutritionCell.className = "menu-table__nutrition";
       const nutritionLines = [];
       if (calories) {
         nutritionLines.push(`열량: ${escapeHtml(calories)}`);

--- a/style.css
+++ b/style.css
@@ -223,6 +223,10 @@ body {
   margin-top: 0.35rem;
 }
 
+.menu-table__nutrition {
+  font-size: calc(1rem - 1pt);
+}
+
 .menu-card__message {
   margin-top: calc(var(--spacing-unit) * 1.1);
   font-size: 0.95rem;


### PR DESCRIPTION
### Motivation
- Make the calorie and nutrition text inside the `영양 정보` column slightly smaller (1pt smaller than menu items) to improve visual hierarchy.

### Description
- Add a `menu-table__nutrition` class to the nutrition `<td>` in `menu.js` (and the built `dist/menu.js`) and add `.menu-table__nutrition { font-size: calc(1rem - 1pt); }` to `style.css`, then rebuild the bundle with `npm run build:menu` to keep `dist/menu.js` in sync.

### Testing
- Ran `npm run build:menu` which completed successfully and updated `dist/menu.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17af9784008331bce1cd900da1f3b2)