### PR TITLE
Add Google Apps Script visit counter to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,17 @@
         </section>
       </main>
     </div>
+    <div id="visit-counter">Loading...</div>
+
+    <script>
+      fetch("https://script.google.com/macros/s/AKfycbzGWSabHvkVOSVaVxkiEjiPm-z3O-Z8ZZiikkUaRh-wSCQY4JBeevU3zdQJSc0v5hcu/exec")
+        .then(res => res.json())
+        .then(data => {
+          document.getElementById("visit-counter").innerText =
+            `today ${data.daily} ｜ total ${data.total}`;
+        });
+    </script>
+
     <script src="menu.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Show daily and total visit counts in the page footer by fetching data from the provided Google Apps Script endpoint so visitors can see site usage at a glance.

### Description
- Inserted a visit counter container (`<div id="visit-counter">Loading...</div>`) and an inline `<script>` that fetches `https://script.google.com/macros/s/AKfycbzGWSabHvkVOSVaVxkiEjiPm-z3O-Z8ZZiikkUaRh-wSCQY4JBeevU3zdQJSc0v5hcu/exec` and sets the element text to `today ${data.daily} ｜ total ${data.total}`, placing the new markup just before the existing ` <script src="menu.js"></script>` include in `index.html`.

### Testing
- No automated tests were run because this change is a markup and inline script insertion only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a182a3e1ad083319f98f4f8c586f423)