### PR TITLE
Handle non-JSON visit counter responses on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,32 @@
 
     <script>
       fetch("https://script.google.com/macros/s/AKfycbzGWSabHvkVOSVaVxkiEjiPm-z3O-Z8ZZiikkUaRh-wSCQY4JBeevU3zdQJSc0v5hcu/exec")
-        .then(res => res.json())
-        .then(data => {
-          document.getElementById("visit-counter").innerText =
-            `today ${data.daily} ｜ total ${data.total}`;
+        .then((res) => res.text())
+        .then((text) => {
+          const counter = document.getElementById("visit-counter");
+          if (!counter) {
+            return;
+          }
+
+          let data;
+          try {
+            data = JSON.parse(text);
+          } catch {
+            console.warn("Visit counter response is not JSON:", text);
+            counter.innerText = "방문자 수를 불러오지 못했습니다.";
+            return;
+          }
+
+          const daily = data?.daily ?? "-";
+          const total = data?.total ?? "-";
+          counter.innerText = `today ${daily} ｜ total ${total}`;
+        })
+        .catch((error) => {
+          console.error("Visit counter fetch failed:", error);
+          const counter = document.getElementById("visit-counter");
+          if (counter) {
+            counter.innerText = "방문자 수를 불러오지 못했습니다.";
+          }
         });
     </script>
 


### PR DESCRIPTION
### Motivation
- Prevent the index page from throwing `SyntaxError` when the visit-counter endpoint returns plain text (e.g. "Visit recorded") by making the visitor counter code resilient to non-JSON responses and network failures.

### Description
- Updated the `index.html` visit counter script to read the response as text, perform `JSON.parse` inside a `try/catch`, and display a friendly fallback `방문자 수를 불러오지 못했습니다.` message to the user when parsing or fetch fails, while safely handling missing `#visit-counter` element.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1835754b648331b72bc02c9c4528d5)