### PR TITLE
Center and brighten visit counter text

### DIFF
--- a/style.css
+++ b/style.css
@@ -233,6 +233,14 @@ body {
   color: var(--text-secondary);
 }
 
+
+#visit-counter {
+  margin: 0 auto calc(var(--spacing-unit) * 1.5);
+  text-align: center;
+  color: #6f95c5;
+  font-size: 0.95rem;
+}
+
 /* For touch devices (iOS, Android, etc.) */
 @media (hover: none) and (pointer: coarse) {
   #menuDateInput {


### PR DESCRIPTION
### Motivation
- Center and brighten the visit counter so the visit count appears visually centered and more legible on the page.

### Description
- Add a `#visit-counter` rule to `style.css` that applies `margin: 0 auto calc(var(--spacing-unit) * 1.5)`, `text-align: center`, `color: #6f95c5`, and `font-size: 0.95rem`.

### Testing
- No automated tests were required for this visual-only CSS update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a183a79dae483319e1ce3528715ba74)