### PR TITLE
Add visit counter element into main layout and style it

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
           <p id="menuMessage" class="menu-card__message" role="status"></p>
         </section>
       </main>
+      <div id="visit-counter">Loading...</div>
     </div>
-    <div id="visit-counter">Loading...</div>
 
     <script>
       fetch("https://script.google.com/macros/s/AKfycbzGWSabHvkVOSVaVxkiEjiPm-z3O-Z8ZZiikkUaRh-wSCQY4JBeevU3zdQJSc0v5hcu/exec")

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
           <p id="menuMessage" class="menu-card__message" role="status"></p>
         </section>
       </main>
-      <div id="visit-counter">Loading...</div>
+      <div id="visit-counter">로딩 중...</div>
     </div>
 
     <script>

--- a/style.css
+++ b/style.css
@@ -233,6 +233,14 @@ body {
   color: var(--text-secondary);
 }
 
+
+#visit-counter {
+  margin: 0 auto calc(var(--spacing-unit) * 1.5);
+  text-align: center;
+  color: #7fa3cf;
+  font-size: 0.95rem;
+}
+
 /* For touch devices (iOS, Android, etc.) */
 @media (hover: none) and (pointer: coarse) {
   #menuDateInput {


### PR DESCRIPTION
### Motivation
- Ensure the visit counter is placed inside the main container for proper layout and give it a consistent visual style.

### Description
- Inserted `div#visit-counter` into `index.html` inside the main wrapper (removed the previous duplicate placement) and added CSS rules for `#visit-counter` in `style.css` to center and style the counter text while leaving the existing fetch script unchanged.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a183a79dae483319e1ce3528715ba74)