### PR TITLE
Require one-time voting token for rating submissions

### DIFF
--- a/dist/menu.js
+++ b/dist/menu.js
@@ -1,4 +1,4 @@
-// Built on 2026-05-29T05:54:33.051Z
+// Built on 2026-05-30T13:28:36.058Z
 (function (global) {
   const MENU_JSON_PATH = "data/menu-data.json";
   const VOTING_WEB_APP_URL = "https://script.google.com/macros/s/AKfycbyWF5Dx2ARrUYMx45P1z28r0-e7yuTa54LaVyRmcuYBY0l5AoFM2vWs2drouC81tMMY/exec";
@@ -350,7 +350,32 @@
       : "별점 보내기";
   }
 
-  function submitRatingRequest(ratingEntry) {
+  async function requestVotingToken() {
+    const response = await fetch(VOTING_WEB_APP_URL, {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        "Accept": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Voting token request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const token = typeof payload?.token === "string" ? payload.token.trim() : "";
+
+    if (!payload?.ok || !token) {
+      throw new Error(payload?.error || "Voting token was not returned by the server.");
+    }
+
+    return token;
+  }
+
+  async function submitRatingRequest(ratingEntry) {
+    const token = await requestVotingToken();
+
     return fetch(VOTING_WEB_APP_URL, {
       method: "POST",
       mode: "no-cors",
@@ -358,6 +383,7 @@
         "Content-Type": "text/plain;charset=utf-8",
       },
       body: JSON.stringify({
+        token,
         name: ratingEntry.name,
         rating: ratingEntry.rating,
       }),

--- a/menu.js
+++ b/menu.js
@@ -349,7 +349,32 @@
       : "별점 보내기";
   }
 
-  function submitRatingRequest(ratingEntry) {
+  async function requestVotingToken() {
+    const response = await fetch(VOTING_WEB_APP_URL, {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        "Accept": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Voting token request failed with status ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const token = typeof payload?.token === "string" ? payload.token.trim() : "";
+
+    if (!payload?.ok || !token) {
+      throw new Error(payload?.error || "Voting token was not returned by the server.");
+    }
+
+    return token;
+  }
+
+  async function submitRatingRequest(ratingEntry) {
+    const token = await requestVotingToken();
+
     return fetch(VOTING_WEB_APP_URL, {
       method: "POST",
       mode: "no-cors",
@@ -357,6 +382,7 @@
         "Content-Type": "text/plain;charset=utf-8",
       },
       body: JSON.stringify({
+        token,
         name: ratingEntry.name,
         rating: ratingEntry.rating,
       }),


### PR DESCRIPTION
### Motivation
- Prevent the web app from being abused by requiring a short-lived one-time token to be obtained before sending any rating.

### Description
- Added an async `requestVotingToken()` helper that performs a `GET` to `VOTING_WEB_APP_URL` with `cache: "no-store"` and validates `response.ok`, `payload.ok`, and a non-empty `token` string.
- Updated `submitRatingRequest()` to call `requestVotingToken()` and include the returned `token` in the `POST` payload so the backend can reject missing, expired, or reused tokens.
- Set `Accept: "application/json"` on the token request and preserved existing `mode: "no-cors"`/`Content-Type` on the POST request.
- Rebuilt the distributable `dist/menu.js` so the shipped bundle includes the same changes.

### Testing
- Ran `npm run build:menu` which completed successfully and produced an updated `dist/menu.js`.
- Ran `node --check menu.js` and `node --check dist/menu.js` to validate syntax, both succeeded. 
- Ran `git diff --check` which reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1ae599d28c8331a183578fcf604eb2)